### PR TITLE
Fixed bug with keydown/keyup

### DIFF
--- a/pygame_player.py
+++ b/pygame_player.py
@@ -1,6 +1,6 @@
 import pygame
 import numpy  # import is unused but required or we fail later
-from pygame.constants import K_DOWN, KEYDOWN, KEYUP, QUIT
+from pygame.constants import K_DOWN, K_UP, KEYDOWN, KEYUP, QUIT
 import pygame.surfarray
 import pygame.key
 
@@ -154,10 +154,12 @@ class PyGamePlayer(object):
         self._game_time += self.get_ms_per_frame()
 
     def _on_event_get(self, _, *args, **kwargs):
-        key_down_events = [pygame.event.Event(KEYDOWN, {"key": x})
-                           for x in self._keys_pressed if x not in self._last_keys_pressed]
-        key_up_events = [pygame.event.Event(KEYUP, {"key": x})
-                         for x in self._last_keys_pressed if x not in self._keys_pressed]
+        key_up_events = []
+        if len(self._last_keys_pressed) > 0:
+            diff_list = list(set( self._last_keys_pressed) - set(self._keys_pressed))
+            key_up_events = [pygame.event.Event(KEYUP, {"key": x}) for x in diff_list] 
+
+        key_down_events = [pygame.event.Event(KEYDOWN, {"key": x}) for x in self._keys_pressed]
 
         result = []
 


### PR DESCRIPTION
You can  test this change by using this code in the pong_player.py example. This code create for me a bug on your current repository. This commit fix this bug. 

`

```
    class PongPlayer(PyGamePlayer):
        def __init__(self, force_game_fps=60, run_real_time=False):
            """
            Example class for playing Pong
            """
            super(PongPlayer, self).__init__(force_game_fps=force_game_fps, run_real_time=run_real_time)
            self.last_bar1_score = 0.0
            self.last_bar2_score = 0.0
            self.it = 0

        def get_keys_pressed(self, screen_array, feedback, terminal):
            # TODO: put an actual learning agent here
            self.it += 1

            if self.it < 100:
                print "K_DOWN"
                return [K_DOWN]
            elif self.it < 200 and self.it >= 100:
                print "K_UP"
                return [K_UP]
            elif self.it >= 200 and self.it < 300:
                print "[]"
                return []
            elif self.it >= 300 and self.it < 350:
                print "K_UP"
                return [K_UP]
            elif self.it >= 350 and self.it < 400:
                print "K_DOWN"
                return [K_DOWN]
            else:
                print "[]"
                return []
```

`

You can also find my issue on your own repository which explain the bug.

Sorry for my bad english.

Thanks you ! 
